### PR TITLE
add horizontal scrolling to code blocks

### DIFF
--- a/_sass/modules/_syntax.scss
+++ b/_sass/modules/_syntax.scss
@@ -1,4 +1,4 @@
-.highlight  { background: #F4F3FB; border: 1px solid #DFDDEE; }
+.highlight  { background: #F4F3FB; border: 1px solid #DFDDEE; overflow: scroll; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
Any pages with code blocks in them were broken on mobile, adding a horizontal scroll bar. This fixes is by adding `overflow: scroll` to the `.highlight` class.