### PR TITLE
add medium-styled links in blog posts

### DIFF
--- a/_sass/_overrides.scss
+++ b/_sass/_overrides.scss
@@ -80,6 +80,15 @@ code {
   font-size: .75em;
 }
 
+.post a:link, .post a:visited {
+  color: #000;
+  text-decoration: none;
+  background-image: linear-gradient(to bottom,rgba(0,0,0,.6) 50%,rgba(0,0,0,0) 50%);
+  background-repeat: repeat-x;
+  background-size: 2px .1em;
+  background-position: 0 1.07em;
+}
+
 progress {
   /* Positioning */
   position: fixed;


### PR DESCRIPTION
This change is a bit subjective, so let me know your thoughts on it. The default link styling was driving me crazy, not because of the colors, but because of the ugly thick underlines. A few years back, Wichary at medium did a nice [writeup](https://medium.design/crafting-link-underlines-on-medium-7c03a9274f9#.pqpcowsoq) on how he went about restyling their links. This PR implements the underline methods conceived in that blog post.

Before:

![screen shot 2017-02-01 at 6 55 35 am](https://cloud.githubusercontent.com/assets/1624279/22506693/d919a89e-e84f-11e6-998d-4a92b5e6ff2f.png)

After:

![screen shot 2017-02-01 at 7 17 55 am](https://cloud.githubusercontent.com/assets/1624279/22506694/dc38dd9c-e84f-11e6-8fe2-dec3563f32e4.png)


## Notes:

- These styles only affect links that are in the blog `.post` class
- I colored them black for now, mainly because I wasn't sure if you had an "official" purple. I think styling them purple might be the best approach to make sure they're differentiated from normal underlined text.
- This overrides the `:visited` selector as well